### PR TITLE
List of post_categories/post_tags broken in the sidebar

### DIFF
--- a/source/entries/categories/category.html
+++ b/source/entries/categories/category.html
@@ -4,7 +4,9 @@ title: Category Archive
 generator: [posts_category_index, pagination]
 pagination:
     provider: page.category_posts
-
+use:  
+    - posts_categories
+    - posts_tags
 ---
 {% block title %}{{ page.title }} "{{ page.category }}"{% endblock %}
 {% block content %}

--- a/source/entries/tags/tag.html
+++ b/source/entries/tags/tag.html
@@ -4,7 +4,9 @@ title: Tag Archive
 generator: [posts_tag_index, pagination]
 pagination:
     provider: page.tag_posts
-
+use:  
+    - posts_categories
+    - posts_tags
 ---
 {% block title %}{{ page.title }} "{{ page.tag }}"{% endblock %}
 {% block content %}


### PR DESCRIPTION
If you see the right sidebar in the tag/category detail, the list of categories and cloud of tags are broken.
e.g
http://dev-human.com/entries/categories/Career/
http://dev-human.com/entries/tags/philosophy/
I have added:
use:  
- posts_categories
- posts_tags
  to category.html and tag.html.
