### PR TITLE
Fix padding on small screens

### DIFF
--- a/source/assets/css/custom.css
+++ b/source/assets/css/custom.css
@@ -26,7 +26,7 @@
     margin-top: 3px;
 }
 
-@media (max-width: 440px) {
+@media (max-width: 768px) {
     .container {
         padding: 10px 5px;
     }


### PR DESCRIPTION
# Introduction

On smaller devices, there's a lot of padding. This PR tries to solve that by removing it around the container classes, so the articles are easier to read and the focus is brought back to the text again.
The breakpoint of 768px is the same as Bootstrap uses for small devices.
# How it looks

This is how it currently looks in production:
![screen shot 2014-10-11 at 18 32 48](https://cloud.githubusercontent.com/assets/106844/4603317/4d75c248-5164-11e4-8e9e-ccbe4f98dcad.png)

This is how it looks with this change:
![screen shot 2014-10-11 at 18 32 01](https://cloud.githubusercontent.com/assets/106844/4603323/5715b93e-5164-11e4-81e2-92b7a3ffbac7.png)

And this is how it looks if #67 is also merged:
![screen shot 2014-10-11 at 18 34 16](https://cloud.githubusercontent.com/assets/106844/4603326/7e3d506c-5164-11e4-89a1-70002d6b0431.png)
