### PR TITLE
Fix for column definition on tablets

### DIFF
--- a/source/_partials/sidebar.twig
+++ b/source/_partials/sidebar.twig
@@ -17,16 +17,11 @@
 
 <div class="widget categories">
     <h3>Categories</h3>
-    <div class="row">
-        <div class="col-sm-6">
-            <ul class="arrow">
-                {% for category,posts in data.posts_categories %}
-                <li><a href="{{ site.url }}/entries/categories/{{ category|url_encode(true) }}">{{ category }}</a></li>
-                {% endfor %}
-            </ul>
-        </div>
-
-    </div>
+    <ul class="arrow">
+        {% for category,posts in data.posts_categories %}
+        <li><a href="{{ site.url }}/entries/categories/{{ category|url_encode(true) }}">{{ category }}</a></li>
+        {% endfor %}
+    </ul>
 </div><!--/.categories-->
 
 <div class="widget tags">

--- a/source/_views/default.twig
+++ b/source/_views/default.twig
@@ -50,12 +50,12 @@
 
     <section id="blog" class="container">
         <div class="row">
-            <div class="col-md-8 col-sm-4">
+            <div class="col-sm-8">
                 <div class="blog">
                     {% block content_wrapper %}{% block content %}{% endblock %}{% endblock %}
                 </div>
             </div><!--/.col-md-8-->
-            <aside class="col-md-4 col-sm-4">
+            <aside class="col-sm-4">
                 {% include "sidebar.twig" %}
             </aside>
         </div><!--/.row-->


### PR DESCRIPTION
# What

Fixes something that can be seen in #69: the 2 main columns aren't defined very well for small devices (tablets >768px).
Also, the categories in the sidebar had a column definition, which forced long categories to use 2 rows, while there was plenty of room, so I removed that column definition.

This change does however not fix the menu being rendered on 2 columns.
# How it looks

This is what it currently looks like:
![screen shot 2014-10-11 at 18 39 30](https://cloud.githubusercontent.com/assets/106844/4603474/8d35ea4a-516c-11e4-98ce-71c46f1396d0.png)

This is what it looks like after these changes:
![screen shot 2014-10-11 at 19 31 51](https://cloud.githubusercontent.com/assets/106844/4603475/95d482f6-516c-11e4-854b-9410b0210aab.png)
