### PR TITLE
Add devhuman domain

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -10,11 +10,13 @@ custom:
   production:
     #local_path: build/production
     local_path: coming_soon
-    certificate: arn:aws:acm:us-east-1:033201381223:certificate/f0e06be4-fd8e-409a-8acc-5d17be1cecee
+    certificate: arn:aws:acm:us-east-1:033201381223:certificate/43981011-8ba0-4290-8f88-3811a12ee1ea
     redirectToMainDomain: true
     domain:
       - dev-human.io
       - www.dev-human.io
+      - devhuman.io
+      - www.devhuman.io
 
 provider:
   name: aws

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,8 +8,7 @@ custom:
     domain:
       - staging.dev-human.io
   production:
-    #local_path: build/production
-    local_path: coming_soon
+    local_path: build/production
     certificate: arn:aws:acm:us-east-1:033201381223:certificate/43981011-8ba0-4290-8f88-3811a12ee1ea
     redirectToMainDomain: true
     domain:


### PR DESCRIPTION
This PR adds the devhuman.io (without dash) domain to the certificate and enables the deploy to production. W00T