### PR TITLE
Build the initial CSS file once if it does not exist yet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,12 @@ node_modules: package.json package-lock.json # Install npm dependencies specifie
 	 ${NODE_RUN} npm install
 
 .PHONY: tailwind
-tailwind: node_modules # Run tailwind once to build the index.css file
+tailwind: node_modules assets/css/index.css # Run tailwind once to build the index.css file
+assets/css/index.css: assets/css/input.css
 	${NODE_RUN} npx tailwindcss -i ./assets/css/input.css -o ./assets/css/index.css --jit
 
 .PHONY: tailwind-watch
-tailwind-watch: node_modules # Run tailwind watch so any changes in the templates are detected and rebuilt
+tailwind-watch: tailwind # Run tailwind watch so any changes in the templates are detected and rebuilt
 	${NODE_RUN} npx tailwindcss -i ./assets/css/input.css -o ./assets/css/index.css --jit --watch
 
 .PHONY: hugo-server
@@ -25,7 +26,7 @@ hugo-server: # Run Hugo in development mode, starting a server on http://localho
 	open http://localhost:1313
 
 .PHONY: start
-start: hugo-server tailwind-watch # Start the full development environment
+start: tailwind hugo-server tailwind-watch # Start the full development environment
 
 .PHONY: build-staging
 build-staging: tailwind # Build the staging website in the build/staging folder


### PR DESCRIPTION
This change allows a new checkout to function property by automatically building assets/css/index.css if it does not exist yet. On subsequent runs of `make start` it will not build if there are no changes to assets/css/input.css.

This siolves the problem for first time use to result in:

```
Attaching to dev-human-hugo-1
dev-human-hugo-1  | Start building sites … 
dev-human-hugo-1  | hugo v0.107.0-2221b5b30a285d01220a26a82305906ad3291880+extended linux/amd64 BuildDate=2022-11-24T13:59:45Z VendorInfo=hugoguru
dev-human-hugo-1  | ERROR 2023/05/12 08:40:18 render of "page" failed: "/src/layouts/_default/baseof.html:9:56": execute of template failed: template: article/single.html:9:56: executing "article/single.html" at <$css.Permalink>: nil pointer evaluating resource.Resource.Permalink
etc..
```